### PR TITLE
README fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ might need but do not belong in requests proper.
 multipart/form-data Encoder
 ---------------------------
 
-The main attraction is a streaming multipart form-data object. It's API looks
+The main attraction is a streaming multipart form-data object. Its API looks
 like:
 
 .. code::


### PR DESCRIPTION
Mostly nitpicky, but the README currently uses `requests_toolkit` instead of `requests_toolbelt`, which is what the code actually says. =D
