### PR TITLE
Add encoding comment to `*.py`

### DIFF
--- a/requests_toolbelt/user_agent.py
+++ b/requests_toolbelt/user_agent.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import platform
 import sys
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import sys
 
 sys.path.insert(0, '.')

--- a/tests/test_multipart_encoder.py
+++ b/tests/test_multipart_encoder.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 import io
 from requests_toolbelt.multipart.encoder import CustomBytesIO, MultipartEncoder

--- a/tests/test_ssladapter.py
+++ b/tests/test_ssladapter.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import betamax
 import requests
 import unittest

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 import sys
 from mock import patch


### PR DESCRIPTION
It existed in some places, but not others, so…
