### PR TITLE
Import metadata from package to setup.py

### DIFF
--- a/requests_toolbelt/__init__.py
+++ b/requests_toolbelt/__init__.py
@@ -10,7 +10,11 @@ See http://toolbelt.rtfd.org/ for documentation
 """
 
 __title__ = 'requests-toolbelt'
+__author__ = 'Ian Cordasco'
+__author_email__ = 'graffatcolmingov@gmail.com'
 __authors__ = 'Ian Cordasco, Cory Benfield'
+__description__ = 'A utility belt for advanced users of python-requests'
+__url__ = 'https://toolbelt.readthedocs.org'
 __license__ = 'Apache v2.0'
 __copyright__ = 'Copyright 2014 Ian Cordasco, Cory Benfield'
 __version__ = '0.2.0'

--- a/setup.py
+++ b/setup.py
@@ -30,16 +30,24 @@ except:
 if not __version__:
     raise RuntimeError('Cannot find version information')
 
+from requests_toolbelt import (
+    __title__,
+    __description__,
+    __author__,
+    __author_email__,
+    __url__,
+)
+
 setup(
-    name="requests-toolbelt",
+    name=__title__,
     version=__version__,
-    description="A utility belt for advanced users of python-requests",
+    description=__description__,
     long_description="\n\n".join([open("README.rst").read(),
                                   open("HISTORY.rst").read()]),
     license=open("LICENSE").read(),
-    author="Ian Cordasco",
-    author_email="graffatcolmingov@gmail.com",
-    url="https://toolbelt.readthedocs.org",
+    author=__author__,
+    author_email=__author_email__,
+    url=__url__,
     packages=['requests_toolbelt'],
     package_data={'': ['LICENSE', 'AUTHORS.rst']},
     include_package_data=True,


### PR DESCRIPTION
Let the metadata live closer to what it describes! :)

---
### If this Pull Request makes you: 😀

Then, give me a high five!  (Why isn’t there an Emoji for “high five”?!  :+1: )

<br>
### If this Pull Request makes you: 😬

Feel free to decline.  I realize it’s slightly off-norm.

<br> 
### If this Pull Request makes you: 😐

A variation on this is to create `__meta__.py` to hold all metadata, and then `import` it wherever it’s needed.  Say the word, and I’ll change it accordingly.
