### PR TITLE
Add support for a multipart/related encoder.

### DIFF
--- a/requests_toolbelt/__init__.py
+++ b/requests_toolbelt/__init__.py
@@ -19,7 +19,7 @@ __version_info__ = tuple(int(i) for i in __version__.split('.'))
 from .adapters import SSLAdapter, SourceAddressAdapter
 from .auth import GuessAuth
 from .multipart import (
-    MultipartEncoder, MultipartEncoderMonitor, MultipartDecoder,
+    MultipartEncoder, MultipartRelatedEncoder, MultipartEncoderMonitor, MultipartDecoder,
     ImproperBodyPartContentException, NonMultipartContentTypeException
     )
 from .streaming_iterator import StreamingIterator

--- a/requests_toolbelt/multipart/__init__.py
+++ b/requests_toolbelt/multipart/__init__.py
@@ -13,13 +13,14 @@ __authors__ = 'Ian Cordasco, Cory Benfield'
 __license__ = 'Apache v2.0'
 __copyright__ = 'Copyright 2014 Ian Cordasco, Cory Benfield'
 
-from .encoder import MultipartEncoder, MultipartEncoderMonitor
+from .encoder import MultipartEncoder, MultipartRelatedEncoder, MultipartEncoderMonitor
 from .decoder import MultipartDecoder
 from .decoder import ImproperBodyPartContentException
 from .decoder import NonMultipartContentTypeException
 
 __all__ = [
     'MultipartEncoder',
+    'MultipartRelatedEncoder',
     'MultipartEncoderMonitor',
     'MultipartDecoder',
     'ImproperBodyPartContentException',

--- a/requests_toolbelt/multipart/encoder.py
+++ b/requests_toolbelt/multipart/encoder.py
@@ -310,6 +310,12 @@ class MultipartEncoderMonitor(object):
         self.callback(self)
         return string
 
+class MultipartRelatedEncoder(MultipartEncoder):
+    @property
+    def content_type(self):
+        return str(
+            'multipart/related; boundary={0}'.format(self.boundary_value)
+        )
 
 def encode_with(string, encoding):
     """Encoding ``string`` with ``encoding`` if necessary.


### PR DESCRIPTION
Ran across this problem when trying to deal with the file upload of the HipChat API v2. All this does is override the content type of the encoder.
