### PR TITLE
Fix "oject" to "object" in MultipartEncoder

### DIFF
--- a/requests_toolbelt/multipart/encoder.py
+++ b/requests_toolbelt/multipart/encoder.py
@@ -19,7 +19,7 @@ class MultipartEncoder(object):
 
     """
 
-    The ``MultipartEncoder`` oject is a generic interface to the engine that
+    The ``MultipartEncoder`` object is a generic interface to the engine that
     will create a ``multipart/form-data`` body for you.
 
     The basic usage is:


### PR DESCRIPTION
A simple typo fix in the docstring.