### PR TITLE
Avoid bailing out with exception upon empty response reason

### DIFF
--- a/requests_toolbelt/utils/dump.py
+++ b/requests_toolbelt/utils/dump.py
@@ -109,7 +109,8 @@ def _dump_response_data(response, prefixes, bytearr):
 def _coerce_to_bytes(data):
     if not isinstance(data, bytes) and hasattr(data, 'encode'):
         data = data.encode('utf-8')
-    return data
+    # Don't bail out with an exception if data is None
+    return data if data is not None else b''
 
 
 def dump_response(response, request_prefix=b'< ', response_prefix=b'> ',


### PR DESCRIPTION
If response reason is empty, `dump_all()` bails out with an exception:

```
Traceback (most recent call last):
  File "test.py", line 34, in get_token
    dump.dump_all(r).decode()
  File "/usr/lib/python3.6/site-packages/requests_toolbelt/utils/dump.py", line 194, in dump_all
    dump_response(response, request_prefix, response_prefix, data)
  File "/usr/lib/python3.6/site-packages/requests_toolbelt/utils/dump.py", line 156, in dump_response
    _dump_response_data(response, prefixes, data)
  File "/usr/lib/python3.6/site-packages/requests_toolbelt/utils/dump.py", line 97, in _dump_response_data
    _coerce_to_bytes(response.reason) + b'\r\n')
TypeError: can't concat bytes to NoneType
```

Fix this by coercing `None` to `b''`; I appreciate that this is by no means an elegant solution, but it does the trick, and I think it's not worth investing even more work into it.