### PR TITLE
Coerce proxy URL to bytes before dumping request

### DIFF
--- a/requests_toolbelt/utils/dump.py
+++ b/requests_toolbelt/utils/dump.py
@@ -44,7 +44,8 @@ def _build_request_path(url, proxy_info):
     uri = compat.urlparse(url)
     proxy_url = proxy_info.get('request_path')
     if proxy_url is not None:
-        return proxy_url, uri
+        request_path = _coerce_to_bytes(proxy_url)
+        return request_path, uri
 
     request_path = _coerce_to_bytes(uri.path)
     if uri.query:


### PR DESCRIPTION
The proxy URL is returned as a string from _build_request_path().
This throws a TypeError when it is added to the prefix and method
in _dump_request_data(). A fix is to coerce the proxy URL to bytes
before returning it.