### PR TITLE
Prevent `to_string` from modifying `MultipartEncoder`'s buffer

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,3 +41,5 @@ Patches and Suggestions
 - Mike Lambert (@mikelambert)
 
 - Ryan Barrett (https://snarfed.org/)
+
+- Adam Dangoor (@adamdangoor)

--- a/requests_toolbelt/multipart/encoder.py
+++ b/requests_toolbelt/multipart/encoder.py
@@ -8,6 +8,7 @@ This holds all of the implementation details of the MultipartEncoder
 
 """
 import contextlib
+import copy
 import io
 import os
 from uuid import uuid4
@@ -279,16 +280,16 @@ class MultipartEncoder(object):
             streaming or reading data from the encoder, this method will only
             return whatever data is left in the encoder.
 
-        .. note::
-
-            This method affects the internal state of the encoder. Calling
-            this method will exhaust the encoder.
-
         :returns: the multipart message
         :rtype: bytes
         """
+        if self.finished:
+            buffer_copy = copy.copy(self._buffer)
+            return buffer_copy.read()
 
-        return self.read()
+        self._load(-1)
+        buffer_copy = copy.copy(self._buffer)
+        return buffer_copy.read()
 
     def read(self, size=-1):
         """Read data from the streaming encoder.

--- a/tests/test_multipart_encoder.py
+++ b/tests/test_multipart_encoder.py
@@ -98,6 +98,9 @@ class TestMultipartEncoder(unittest.TestCase):
             '--this-is-a-boundary--\r\n'
         ).encode()
 
+    def test_to_string_twice(self):
+        assert self.instance.to_string() == self.instance.to_string()
+
     def test_content_type(self):
         expected = 'multipart/form-data; boundary=this-is-a-boundary'
         assert self.instance.content_type == expected


### PR DESCRIPTION
Previously, `MultipartEncoder`'s behaviour was changed after using the
`to_string` method. This was confusing behaviour. Now, the buffer is
copied internally, so the `MultipartEncoder` remains the same after
using `to_string`.