### PR TITLE
Remove py33 from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,6 @@ matrix:
     env: TOXENV=py27 REQUESTS_VERSION="===2.2.1"
   - python: 2.7
     env: TOXENV=py27 REQUESTS_VERSION="===2.1.0"
-  - python: 3.3
-    env: TOXENV=py33
-  - python: 3.3
-    env: TOXENV=py33 REQUESTS_VERSION="===2.2.1"
-  - python: 3.3
-    env: TOXENV=py33 REQUESTS_VERSION="===2.1.0"
   - python: 3.4
     env: TOXENV=py34
   - python: 3.4
@@ -35,6 +29,18 @@ matrix:
     env: TOXENV=py35 REQUESTS_VERSION="===2.2.1"
   - python: 3.5
     env: TOXENV=py35 REQUESTS_VERSION="===2.1.0"
+  - python: 3.6
+    env: TOXENV=py36
+  - python: 3.6
+    env: TOXENV=py36 REQUESTS_VERSION="===2.2.1"
+  - python: 3.6
+    env: TOXENV=py36 REQUESTS_VERSION="===2.1.0"
+  - python: nightly
+    env: TOXENV=py37
+  - python: nightly
+    env: TOXENV=py37 REQUESTS_VERSION="===2.2.1"
+  - python: nightly
+    env: TOXENV=py37 REQUESTS_VERSION="===2.1.0"
   - env: TOXENV=py27-flake8
   - env: TOXENV=py34-flake8
   - env: TOXENV=docstrings

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,{py27,py34}-flake8,docstrings
+envlist = py27,py34,py35,py36,pypy,{py27,py34}-flake8,docstrings
 
 [testenv]
 pip_pre = False


### PR DESCRIPTION
Add Python 3.6 and nightly testing to the travis matrix.