### PR TITLE
Make sure SourceAddressAdapter can be pickled

### DIFF
--- a/requests_toolbelt/adapters/source.py
+++ b/requests_toolbelt/adapters/source.py
@@ -54,6 +54,15 @@ class SourceAddressAdapter(HTTPAdapter):
 
         super(SourceAddressAdapter, self).__init__(**kwargs)
 
+    def __getstate__(self):
+        state = super(SourceAddressAdapter, self).__getstate__()
+        state['source_address'] = self.source_address
+        return state
+
+    def __setstate__(self, state):
+        self.source_address = state['source_address']
+        super(SourceAddressAdapter, self).__setstate__(state)
+
     def init_poolmanager(self, connections, maxsize, block=False):
         self.poolmanager = poolmanager.PoolManager(
             num_pools=connections,


### PR DESCRIPTION
This commit overrides `__getstate__` and `__setstate__` to store the source  address as part of the state. As a result, the `SourceAddressAdapter`  can be pickled correctly.

For more information, see: https://stackoverflow.com/questions/27711907/python-unpickle-a-object-with-a-class-instance-inside