### PR TITLE
MAINT: Fix typo in MultipartDecoder docstring

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,3 +41,5 @@ Patches and Suggestions
 - Mike Lambert (@mikelambert)
 
 - Ryan Barrett (https://snarfed.org/)
+
+- Victor Grau Serrat (@lacabra)

--- a/requests_toolbelt/multipart/decoder.py
+++ b/requests_toolbelt/multipart/decoder.py
@@ -45,7 +45,7 @@ class BodyPart(object):
     subpart of a multipart response. It is expected that these will
     generally be created by objects of the ``MultipartDecoder`` class.
 
-    Like ``Response``, there is a ``CaseInsensitiveDict`` object named header,
+    Like ``Response``, there is a ``CaseInsensitiveDict`` object named headers,
     ``content`` to access bytes, ``text`` to access unicode, and ``encoding``
     to access the unicode codec.
 
@@ -85,7 +85,7 @@ class MultipartDecoder(object):
         response = request.get(url)
         decoder = MultipartDecoder.from_response(response)
         for part in decoder.parts:
-            print(part.header['content-type'])
+            print(part.headers['content-type'])
 
     If the multipart content is not from a response, basic usage is::
 
@@ -93,7 +93,7 @@ class MultipartDecoder(object):
 
         decoder = MultipartDecoder(content, content_type)
         for part in decoder.parts:
-            print(part.header['content-type'])
+            print(part.headers['content-type'])
 
     For both these usages, there is an optional ``encoding`` parameter. This is
     a string, which is the name of the unicode codec to use (default is

--- a/requests_toolbelt/multipart/encoder.py
+++ b/requests_toolbelt/multipart/encoder.py
@@ -345,7 +345,7 @@ class MultipartEncoderMonitor(object):
 
         m = MultipartEncoder(fields={'field0': 'value0'})
         monitor = MultipartEncoderMonitor(m, callback)
-        headers = {'Content-Type': montior.content_type}
+        headers = {'Content-Type': monitor.content_type}
         r = requests.post('https://httpbin.org/post', data=monitor,
                           headers=headers)
 


### PR DESCRIPTION
MultipartDecoder docstring refers to part.header, when it should be part.headers