### PR TITLE
threaded/tread.py: Fix numerous test tracebacks

### DIFF
--- a/requests_toolbelt/threaded/thread.py
+++ b/requests_toolbelt/threaded/thread.py
@@ -36,6 +36,8 @@ class SessionThread(object):
             self._jobs.task_done()
 
     def _make_request(self):
+        if self._jobs is None:
+            return
         while True:
             try:
                 kwargs = self._jobs.get_nowait()


### PR DESCRIPTION
Adding this check and return prevents numerous test trace:

Exception in thread 12f554d5-f61f-44d9-bc69-023714627952:
Traceback (most recent call last):
  File "/usr/lib64/python3.4/threading.py", line 911, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.4/threading.py", line 859, in run
    self._target(*self._args, **self._kwargs)
  File "/home/bdolbec/git/toolbelt/requests_toolbelt/threaded/thread.py", line 43, in _make_request
    kwargs = self._jobs.get_nowait()
AttributeError: 'NoneType' object has no attribute 'get_nowait'