### PR TITLE
Allow users to manipulate data before dumping

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -47,3 +47,5 @@ Patches and Suggestions
 - Yorgos Pagles <yorgos@pagles.org>
 
 - Thomas Hauk <thauk@copperleaf.com>
+
+- Morten Lied Johansen <mortenjo@ifi.uio.no>

--- a/docs/dumputils.rst
+++ b/docs/dumputils.rst
@@ -10,8 +10,38 @@ you may need to look to find it. In :mod:`requests_toolbelt.utils.dump` there
 are two functions that will return a :class:`bytearray` with the information
 retrieved from a response object.
 
+Sanitizing information before dumping
+-------------------------------------
+
+When debugging, it is quite often useful to dump the request or response to
+debugging log, where it can be inspected. The problem is that often the
+request or response can contain sensitive data that should not be stored in
+a logfile on disk.
+
+To solve this, it is possible to supply a :class:`Sanitizer` which can
+manipulate the body or the headers before they are dumped. The default is
+to not do anything. For convenience, :class:`HeaderSanitizer` is provided,
+which will redact the value of headers that are commonly considered sensitive
+(See :data:`SENSITIVE_HEADERS`).
+
+You can make any sanitizing you need by subclassing :class:`Sanitizer` and
+passing in an instance to :py:func:`dump_all` or :func:`dump_response`.
+
+Public members
+--------------
+
 .. autofunction::
     requests_toolbelt.utils.dump.dump_all
 
 .. autofunction::
     requests_toolbelt.utils.dump.dump_response
+
+.. autoclass::
+    requests_toolbelt.utils.dump.Sanitizer
+    :members:
+
+.. autoclass::
+    requests_toolbelt.utils.dump.HeaderSanitizer
+
+.. autodata::
+    requests_toolbelt.utils.dump.SENSITIVE_HEADERS

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -296,7 +296,7 @@ class TestResponsePrivateFunctions(RequestResponseMixin):
             request=self.request,
             prefixes=prefixes,
             bytearr=array,
-            sanitizer=dump.HEADER_SANITIZER,
+            sanitizer=dump.HeaderSanitizer(),
         )
 
         assert b'request:password: #REDACTED#\r\n' in array
@@ -412,7 +412,7 @@ class TestResponsePrivateFunctions(RequestResponseMixin):
             response=self.response,
             prefixes=prefixes,
             bytearr=array,
-            sanitizer=dump.HEADER_SANITIZER,
+            sanitizer=dump.HeaderSanitizer(),
         )
 
         assert b'response:SamlResponse: #REDACTED#\r\n' in array


### PR DESCRIPTION
Dumping the request/response is useful for debugging, but that means
the data usually will end up in logfiles or other places. Since many
requests or responses will contain sensitive data (authentication
tokens, username, cookies etc), it is sometimes necessary to redact some
of that information before dumping it. This implementation provides a
way to supply your own sanitizer, or use the provided sanitizer which
will redact information in a number of known sensitive headers.

Closes #226