### PR TITLE
Move import of ABCs from collections to collections.abc

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -47,3 +47,6 @@ Patches and Suggestions
 - Yorgos Pagles <yorgos@pagles.org>
 
 - Thomas Hauk <thauk@copperleaf.com>
+
+- Achim Herwig <python@wodca.de>
+

--- a/requests_toolbelt/_compat.py
+++ b/requests_toolbelt/_compat.py
@@ -8,7 +8,6 @@ urllib3 without providing a shim.
     This module is private. If you use it, and something breaks, you were
     warned
 """
-from collections import Mapping, MutableMapping
 import sys
 
 import requests
@@ -53,9 +52,11 @@ else:
 PY3 = sys.version_info > (3, 0)
 
 if PY3:
+    from collections.abc import Mapping, MutableMapping
     import queue
     from urllib.parse import urlencode, urljoin
 else:
+    from collections import Mapping, MutableMapping
     import Queue as queue
     from urllib import urlencode
     from urlparse import urljoin


### PR DESCRIPTION
in the version-specific part of the _compat module.

Starting from Python 3.3, importing ABCs from collections.abc is suggested.
From Python 3.7 on there is a DeprecationWarning, from Python 3.8 there will be an error.

Fixes #228.