### PR TITLE
Handle missing pyopenssl dependency

### DIFF
--- a/requests_toolbelt/_compat.py
+++ b/requests_toolbelt/_compat.py
@@ -56,7 +56,10 @@ else:
         from requests.packages.urllib3.contrib.pyopenssl \
                 import PyOpenSSLContext
     except ImportError:
-        from urllib3.contrib.pyopenssl import PyOpenSSLContext
+        try:
+            from urllib3.contrib.pyopenssl import PyOpenSSLContext
+        except ImportError:
+            PyOpenSSLContext = None
 
 PY3 = sys.version_info > (3, 0)
 


### PR DESCRIPTION
Alternative to #242
Fixes #241 

Handle the case where `pyopenssl` is not installed and fall back to default of setting `PyOpenSSLContext` to `None`.