### PR TITLE
Update trove classifiers to document support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,11 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )


### PR DESCRIPTION
Python 3.3 is EOL and testing was removed in e4eb0ccf05eff70fc7932467a5cbd4c657b8c4c3.

requests-toolbelt support Python 3.6, 3.7, and PyPy.