### PR TITLE
Fix collections.abc deprecation warning in downloadutils

### DIFF
--- a/requests_toolbelt/downloadutils/stream.py
+++ b/requests_toolbelt/downloadutils/stream.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Utilities for dealing with streamed requests."""
-import collections
 import os.path
 import re
 
@@ -158,7 +157,7 @@ def stream_response_to_file(response, path=None, chunksize=_DEFAULT_CHUNKSIZE):
     pre_opened = False
     fd = None
     filename = None
-    if path and isinstance(getattr(path, 'write', None), collections.Callable):
+    if path and callable(getattr(path, 'write', None)):
         pre_opened = True
         fd = path
         filename = getattr(fd, 'name', None)


### PR DESCRIPTION
Warning appears as:

```
tests/test_downloadutils.py::test_stream_response_to_specific_filename
  requests_toolbelt/downloadutils/stream.py:161: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    if path and isinstance(getattr(path, 'write', None), collections.Callable):
```