### PR TITLE
Rename [wheel] section to [bdist_wheel] as the former is legacy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[wheel]
+[bdist_wheel]
 universal = 1


### PR DESCRIPTION
For additional details, see:

https://github.com/pypa/wheel/blob/3dc261abc98a5e43bc7fcf5783d080aaf8f9f0cf/wheel/bdist_wheel.py#L127-L133

http://pythonwheels.com/