### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -44,7 +44,7 @@ result in a response that is deemed necessary and appropriate to the
 circumstances. Maintainers are obligated to maintain confidentiality
 with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the `Contributor Covenant`_, version 
+This Code of Conduct is adapted from the `Contributor Covenant`_, version
 1.3.0, available at http://contributor-covenant.org/version/1/3/0/
 
 .. _Contributor Covenant: http://contributor-covenant.org

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,3 @@
-Please read the `documentation 
-<https://toolbelt.readthedocs.org/en/latest/contributing.html>`_ to understand 
+Please read the `documentation
+<https://toolbelt.readthedocs.org/en/latest/contributing.html>`_ to understand
 the suggested workflow to contribute to this project.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,7 +15,7 @@ Fixed Bugs
 New Features
 ~~~~~~~~~~~~
 
-- Add X509 Adapter that can handle PKCS12 
+- Add X509 Adapter that can handle PKCS12
 - Add stateless solution for streaming files by MultipartEncoder from one host to another (in chunks)
 
 Fixed Bugs
@@ -29,13 +29,13 @@ Fixed Bugs
 - Fix bug when ``MultipartEncoder`` is asked to encode zero parts
 - Correct the type of non string request body dumps
 - Removed content from being stored in MultipartDecoder
-- Fix bug by enabling support for contenttype with capital letters. 
+- Fix bug by enabling support for contenttype with capital letters.
 - Coerce proxy URL to bytes before dumping request
 - Avoid bailing out with exception upon empty response reason
 - Corrected Pool documentation
 - Corrected parentheses match in example usage
 - Fix "oject" to "object" in ``MultipartEncoder``
-- Fix URL for the project after the move 
+- Fix URL for the project after the move
 - Add fix for OSX TCPKeepAliveAdapter
 
 Miscellaneous

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 The Requests Toolbelt
 =====================
 
-This is just a collection of utilities for `python-requests`_, but don't 
-really belong in ``requests`` proper. The minimum tested requests version is 
-``2.1.0``. In reality, the toolbelt should work with ``2.0.1`` as well, but 
+This is just a collection of utilities for `python-requests`_, but don't
+really belong in ``requests`` proper. The minimum tested requests version is
+``2.1.0``. In reality, the toolbelt should work with ``2.0.1`` as well, but
 some idiosyncracies prevent effective or sane testing on that version.
 
 ``pip install requests-toolbelt`` to get started!
@@ -68,8 +68,8 @@ You can easily construct a requests-style ``User-Agent`` string::
 SSLAdapter
 ----------
 
-The ``SSLAdapter`` was originally published on `Cory Benfield's blog`_. 
-This adapter allows the user to choose one of the SSL protocols made available 
+The ``SSLAdapter`` was originally published on `Cory Benfield's blog`_.
+This adapter allows the user to choose one of the SSL protocols made available
 in Python's ``ssl`` module for outgoing HTTPS connections:
 
 .. code-block:: python
@@ -84,7 +84,7 @@ in Python's ``ssl`` module for outgoing HTTPS connections:
 cookies/ForgetfulCookieJar
 --------------------------
 
-The ``ForgetfulCookieJar`` prevents a particular requests session from storing 
+The ``ForgetfulCookieJar`` prevents a particular requests session from storing
 cookies:
 
 .. code-block:: python

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -248,9 +248,9 @@ specifically for that domain, instead of adding it to every ``https://`` and
 X509Adapter
 -----------
 
-Requests supports SSL Verification using a certificate in .pem format by default. 
+Requests supports SSL Verification using a certificate in .pem format by default.
 In some cases it is necessary to pass a full cert chain as part of a request or it
-is deemed too great a risk to decrypt the certificate into a .pem file.  
+is deemed too great a risk to decrypt the certificate into a .pem file.
 
 For such use cases we have created
 :class:`~requests_toolbelt.adapters.x509.X509Adapter`.
@@ -266,4 +266,3 @@ Example usage:
       s.mount('https://', a)
 
 .. autoclass:: requests_toolbelt.adapters.x509.X509Adapter
-

--- a/docs/deprecated.rst
+++ b/docs/deprecated.rst
@@ -3,8 +3,8 @@
 Deprecated Requests Utilities
 =============================
 
-Requests has `decided`_ to deprecate some utility functions in 
-:mod:`requests.utils`. To ease users' lives, they've been moved to 
+Requests has `decided`_ to deprecate some utility functions in
+:mod:`requests.utils`. To ease users' lives, they've been moved to
 :mod:`requests_toolbelt.utils.deprecated`.
 
 .. automodule:: requests_toolbelt.utils.deprecated

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,4 +47,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/tests/test_multipart_decoder.py
+++ b/tests/test_multipart_decoder.py
@@ -188,4 +188,3 @@ class TestMultipartDecoder(unittest.TestCase):
         assert decoder_2.parts[0].headers[b'Header-1'] == b'Header-Value-1'
         assert len(decoder_2.parts[1].headers) == 0
         assert decoder_2.parts[1].content == b'Body 2, Line 1'
-

--- a/tests/test_x509_adapter.py
+++ b/tests/test_x509_adapter.py
@@ -11,7 +11,7 @@ else:
     PYOPENSSL_AVAILABLE = True
     from requests_toolbelt.adapters.x509 import X509Adapter
     from cryptography.hazmat.primitives.serialization import (
-        Encoding, 
+        Encoding,
         PrivateFormat,
         NoEncryption,
         BestAvailableEncryption
@@ -42,10 +42,10 @@ class TestX509Adapter(unittest.TestCase):
         cert_bytes = p12.get_certificate().to_cryptography().public_bytes(Encoding.PEM)
         pk_bytes = p12.get_privatekey().\
                        to_cryptography_key().\
-                       private_bytes(Encoding.PEM, PrivateFormat.PKCS8, 
+                       private_bytes(Encoding.PEM, PrivateFormat.PKCS8,
                                      BestAvailableEncryption(self.pkcs12_password_bytes))
 
-        adapter = X509Adapter(max_retries=3, cert_bytes=cert_bytes, 
+        adapter = X509Adapter(max_retries=3, cert_bytes=cert_bytes,
                               pk_bytes=pk_bytes, password=self.pkcs12_password_bytes)
         self.session.mount('https://', adapter)
         recorder = get_betamax(self.session)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pyopenssl
     ndg-httpsclient
     betamax>0.5.0
-commands = 
+commands =
     py.test {posargs}
 
 [testenv:noopenssl]


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.