### PR TITLE
Use automatic numbering for positional .format() replacement fields

### DIFF
--- a/docs/threading.rst
+++ b/docs/threading.rst
@@ -50,8 +50,8 @@ Here's an example:
     p.join_all()
 
     for response in p.responses():
-        print('GET {0}. Returned {1}.'.format(response.request_kwargs['url'],
-                                              response.status_code))
+        print('GET {}. Returned {}.'.format(response.request_kwargs['url'],
+                                            response.status_code))
 
 This is clearly a bit underwhelming. This is why there's a short-cut class
 method to create a :class:`~requests_toolbelt.threaded.pool.Pool` from a list
@@ -69,8 +69,8 @@ of URLs.
     p.join_all()
 
     for response in p.responses():
-        print('GET {0}. Returned {1}.'.format(response.request_kwargs['url'],
-                                              response.status_code))
+        print('GET {}. Returned {}.'.format(response.request_kwargs['url'],
+                                            response.status_code))
 
 If one of the URLs in your list throws an exception, it will be accessible
 from the :meth:`~Pool.exceptions` generator.
@@ -87,8 +87,8 @@ from the :meth:`~Pool.exceptions` generator.
     p.join_all()
 
     for exc in p.exceptions():
-        print('GET {0}. Raised {1}.'.format(exc.request_kwargs['url'],
-                                            exc.message))
+        print('GET {}. Raised {}.'.format(exc.request_kwargs['url'],
+                                          exc.message))
 
 If instead, you want to retry the exceptions that have been raised you can do
 the following:

--- a/examples/monitor/progress_bar.py
+++ b/examples/monitor/progress_bar.py
@@ -37,6 +37,6 @@ if __name__ == '__main__':
     monitor = MultipartEncoderMonitor(encoder, callback)
     r = requests.post('https://httpbin.org/post', data=monitor,
                       headers={'Content-Type': monitor.content_type})
-    print('\nUpload finished! (Returned status {0} {1})'.format(
+    print('\nUpload finished! (Returned status {} {})'.format(
         r.status_code, r.reason
         ))

--- a/requests_toolbelt/adapters/appengine.py
+++ b/requests_toolbelt/adapters/appengine.py
@@ -200,7 +200,7 @@ def _check_version():
     if gaecontrib is None:
         raise exc.VersionMismatchError(
             "The toolbelt requires at least Requests 2.10.0 to be "
-            "installed. Version {0} was found instead.".format(
+            "installed. Version {} was found instead.".format(
                 requests.__version__
             )
         )

--- a/requests_toolbelt/adapters/x509.py
+++ b/requests_toolbelt/adapters/x509.py
@@ -122,7 +122,7 @@ class X509Adapter(HTTPAdapter):
         if PyOpenSSLContext is None:
             raise exc.VersionMismatchError(
                 "The X509Adapter requires at least Requests 2.12.0 to be "
-                "installed. Version {0} was found instead.".format(
+                "installed. Version {} was found instead.".format(
                     requests.__version__
                 )
             )
@@ -134,8 +134,8 @@ def check_cert_dates(cert):
     now = datetime.utcnow()
     if cert.not_valid_after < now or cert.not_valid_before > now:
         raise ValueError('Client certificate expired: Not After: '
-                         '{0:%Y-%m-%d %H:%M:%SZ} '
-                         'Not Before: {1:%Y-%m-%d %H:%M:%SZ}'
+                         '{:%Y-%m-%d %H:%M:%SZ} '
+                         'Not Before: {:%Y-%m-%d %H:%M:%SZ}'
                          .format(cert.not_valid_after, cert.not_valid_before))
 
 

--- a/requests_toolbelt/auth/handler.py
+++ b/requests_toolbelt/auth/handler.py
@@ -60,7 +60,7 @@ class AuthHandler(AuthBase):
         return auth(request)
 
     def __repr__(self):
-        return '<AuthHandler({0!r})>'.format(self.strategies)
+        return '<AuthHandler({!r})>'.format(self.strategies)
 
     def _make_uniform(self):
         existing_strategies = list(self.strategies.items())

--- a/requests_toolbelt/downloadutils/stream.py
+++ b/requests_toolbelt/downloadutils/stream.py
@@ -130,7 +130,7 @@ def stream_response_to_file(response, path=None, chunksize=_DEFAULT_CHUNKSIZE):
             r = requests.get(url, stream=True)
             filename = stream.stream_response_to_file(r, path=fd)
 
-        print('{0} saved to {1}'.format(url, filename))
+        print('{} saved to {}'.format(url, filename))
 
     .. code-block:: python
 

--- a/requests_toolbelt/multipart/decoder.py
+++ b/requests_toolbelt/multipart/decoder.py
@@ -115,7 +115,7 @@ class MultipartDecoder(object):
         mimetype = ct_info[0]
         if mimetype.split('/')[0].lower() != 'multipart':
             raise NonMultipartContentTypeException(
-                "Unexpected mimetype in content-type: '{0}'".format(mimetype)
+                "Unexpected mimetype in content-type: '{}'".format(mimetype)
             )
         for item in ct_info[1:]:
             attr, value = _split_on_find(

--- a/requests_toolbelt/multipart/encoder.py
+++ b/requests_toolbelt/multipart/encoder.py
@@ -89,7 +89,7 @@ class MultipartEncoder(object):
         self.boundary_value = boundary or uuid4().hex
 
         # Computed boundary
-        self.boundary = '--{0}'.format(self.boundary_value)
+        self.boundary = '--{}'.format(self.boundary_value)
 
         #: Encoding of the data being passed in
         self.encoding = encoding
@@ -148,7 +148,7 @@ class MultipartEncoder(object):
         return self._len or self._calculate_length()
 
     def __repr__(self):
-        return '<MultipartEncoder: {0!r}>'.format(self.fields)
+        return '<MultipartEncoder: {!r}>'.format(self.fields)
 
     def _calculate_length(self):
         """
@@ -273,7 +273,7 @@ class MultipartEncoder(object):
     @property
     def content_type(self):
         return str(
-            'multipart/form-data; boundary={0}'.format(self.boundary_value)
+            'multipart/form-data; boundary={}'.format(self.boundary_value)
             )
 
     def to_string(self):

--- a/tests/test_multipart_decoder.py
+++ b/tests/test_multipart_decoder.py
@@ -128,7 +128,7 @@ class TestMultipartDecoder(unittest.TestCase):
     def test_header_of_parts(self):
         def parts_header_equal(part, sample):
             return part.headers[b'Content-Disposition'] == encode_with(
-                'form-data; name="{0}"'.format(sample[0]), 'utf-8'
+                'form-data; name="{}"'.format(sample[0]), 'utf-8'
             )
 
         parts_iter = zip(self.decoded_1.parts, self.sample_1)

--- a/tests/threaded/test_pool.py
+++ b/tests/threaded/test_pool.py
@@ -57,7 +57,7 @@ class TestPool(unittest.TestCase):
 
     def test_from_exceptions_populates_a_queue(self):
         """Ensure a Queue is properly populated from exceptions."""
-        urls = ["https://httpbin.org/get?n={0}".format(n) for n in range(5)]
+        urls = ["https://httpbin.org/get?n={}".format(n) for n in range(5)]
         Exc = pool.ThreadException
         excs = (Exc({'method': 'GET', 'url': url}, None) for url in urls)
 
@@ -74,7 +74,7 @@ class TestPool(unittest.TestCase):
 
     def test_from_urls_constructs_get_requests(self):
         """Ensure a Queue is properly populated from an iterable of urls."""
-        urls = ["https://httpbin.org/get?n={0}".format(n) for n in range(5)]
+        urls = ["https://httpbin.org/get?n={}".format(n) for n in range(5)]
 
         job_queue = mock.MagicMock()
         with mock.patch.object(queue, 'Queue', return_value=job_queue):
@@ -95,7 +95,7 @@ class TestPool(unittest.TestCase):
                 final.update(d)
             return final
 
-        urls = ["https://httpbin.org/get?n={0}".format(n) for n in range(5)]
+        urls = ["https://httpbin.org/get?n={}".format(n) for n in range(5)]
 
         kwargs = {'stream': True, 'headers': {'Accept': 'application/json'}}
         job_queue = mock.MagicMock()


### PR DESCRIPTION
The feature was added in Python 2.7 and available in all supported
Python versions. Slightly simplifies the .format() expressions.

https://docs.python.org/3/whatsnew/2.7.html#other-language-changes

> The str.format() method now supports automatic numbering of the
> replacement fields. This makes using str.format() more closely
> resemble using %s formatting ...