### PR TITLE
Fix unhandled exceptions from threads during tests

### DIFF
--- a/tests/threaded/test_pool.py
+++ b/tests/threaded/test_pool.py
@@ -26,32 +26,37 @@ class TestPool(unittest.TestCase):
 
     def test_number_of_processes_can_be_arbitrary(self):
         """Show that the number of processes can be set."""
-        p = pool.Pool(None, num_processes=100)
+        job_queue = queue.Queue()
+        p = pool.Pool(job_queue, num_processes=100)
         assert p._processes == 100
         assert len(p._pool) == 100
 
-        p = pool.Pool(None, num_processes=1)
+        job_queue = queue.Queue()
+        p = pool.Pool(job_queue, num_processes=1)
         assert p._processes == 1
         assert len(p._pool) == 1
 
     def test_initializer_is_called(self):
         """Ensure that the initializer function is called."""
+        job_queue = queue.Queue()
         initializer = mock.MagicMock()
-        pool.Pool(None, num_processes=1, initializer=initializer)
+        pool.Pool(job_queue, num_processes=1, initializer=initializer)
         assert initializer.called is True
         initializer.assert_called_once_with(mock.ANY)
 
     def test_auth_generator_is_called(self):
         """Ensure that the auth_generator function is called."""
+        job_queue = queue.Queue()
         auth_generator = mock.MagicMock()
-        pool.Pool(None, num_processes=1, auth_generator=auth_generator)
+        pool.Pool(job_queue, num_processes=1, auth_generator=auth_generator)
         assert auth_generator.called is True
         auth_generator.assert_called_once_with(mock.ANY)
 
     def test_session_is_called(self):
         """Ensure that the session function is called."""
+        job_queue = queue.Queue()
         session = mock.MagicMock()
-        pool.Pool(None, num_processes=1, session=session)
+        pool.Pool(job_queue, num_processes=1, session=session)
         assert session.called is True
         session.assert_called_once_with()
 

--- a/tests/threaded/test_thread.py
+++ b/tests/threaded/test_thread.py
@@ -19,6 +19,8 @@ def _make_mocks():
 
 def _initialize_a_session_thread(session=None, job_queue=None,
                                  response_queue=None, exception_queue=None):
+    if job_queue is None:
+        job_queue = queue.Queue()
     with mock.patch.object(threading, 'Thread') as Thread:
         thread_instance = mock.MagicMock()
         Thread.return_value = thread_instance
@@ -52,10 +54,11 @@ class TestSessionThread(unittest.TestCase):
 
     def test_is_alive_proxies_to_worker(self):
         """Test that we proxy the is_alive method to the Thread."""
+        job_queue = queue.Queue()
         with mock.patch.object(threading, 'Thread') as Thread:
             thread_instance = mock.MagicMock()
             Thread.return_value = thread_instance
-            st = thread.SessionThread(None, None, None, None)
+            st = thread.SessionThread(None, job_queue, None, None)
 
         st.is_alive()
         thread_instance.is_alive.assert_called_once_with()


### PR DESCRIPTION
A queue.Queue() object was not always passed to SessionThread. In this
case, SessionThread._make_request() would raise an exception trying to
call methods on the expected object. Now, always pass a usable object to
SessionThread.

Previously appeared as:

    Traceback (most recent call last):
      File "/usr/lib64/python3.7/threading.py", line 917, in _bootstrap_inner
        self.run()
      File "/usr/lib64/python3.7/threading.py", line 865, in run
        self._target(*self._args, **self._kwargs)
      File "toolbelt/requests_toolbelt/threaded/thread.py", line 41, in _make_request
        kwargs = self._jobs.get_nowait()
    AttributeError: 'NoneType' object has no attribute 'get_nowait'

    Exception in thread cd08fad6-d21d-41b0-921e-737a149b12be:
    Traceback (most recent call last):
      File "/usr/lib64/python3.7/threading.py", line 917, in _bootstrap_inner
        self.run()
      File "/usr/lib64/python3.7/threading.py", line 865, in run
        self._target(*self._args, **self._kwargs)
      File "toolbelt/requests_toolbelt/threaded/thread.py", line 41, in _make_request
        kwargs = self._jobs.get_nowait()
    AttributeError: 'NoneType' object has no attribute 'get_nowait'

    Exception in thread 4fb72f0d-ba1c-4a78-97a2-4a7283ea01fe:
    Traceback (most recent call last):
      File "/usr/lib64/python3.7/threading.py", line 917, in _bootstrap_inner
        self.run()
      File "/usr/lib64/python3.7/threading.py", line 865, in run
        self._target(*self._args, **self._kwargs)
      File "toolbelt/requests_toolbelt/threaded/thread.py", line 41, in _make_request
        kwargs = self._jobs.get_nowait()
    AttributeError: 'NoneType' object has no attribute 'get_nowait'

    Exception in thread 5f3711af-0c01-4821-9e25-8074bbbf769b:
    Traceback (most recent call last):
      File "/usr/lib64/python3.7/threading.py", line 917, in _bootstrap_inner
        self.run()
      File "/usr/lib64/python3.7/threading.py", line 865, in run
        self._target(*self._args, **self._kwargs)
      File "toolbelt/requests_toolbelt/threaded/thread.py", line 41, in _make_request
        kwargs = self._jobs.get_nowait()
    AttributeError: 'NoneType' object has no attribute 'get_nowait'