### PR TITLE
Add Python 3.7 and PyPy to the Travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: false
 before_script:
@@ -14,8 +15,10 @@ matrix:
   - python: 2.7
     env: TOXENV=py27
   - python: 2.7
+    dist: trusty
     env: TOXENV=py27 REQUESTS_VERSION="===2.2.1"
   - python: 2.7
+    dist: trusty
     env: TOXENV=py27 REQUESTS_VERSION="===2.1.0"
   - python: 3.4
     env: TOXENV=py34
@@ -35,16 +38,38 @@ matrix:
     env: TOXENV=py36 REQUESTS_VERSION="===2.2.1"
   - python: 3.6
     env: TOXENV=py36 REQUESTS_VERSION="===2.1.0"
-  - python: nightly
+  - python: 3.7
     env: TOXENV=py37
-  - python: nightly
+  - python: 3.7
     env: TOXENV=py37 REQUESTS_VERSION="===2.2.1"
-  - python: nightly
+  - python: 3.7
     env: TOXENV=py37 REQUESTS_VERSION="===2.1.0"
+  - python: pypy2.7-6.0
+    env: TOXENV=pypy
+  - python: pypy
+    dist: trusty
+    env: TOXENV=pypy REQUESTS_VERSION="===2.2.1"
+  - python: pypy
+    dist: trusty
+    env: TOXENV=pypy REQUESTS_VERSION="===2.1.0"
+  - python: pypy3.5-6.0
+    env: TOXENV=pypy3
+  - python: pypy3.5-6.0
+    env: TOXENV=pypy3 REQUESTS_VERSION="===2.2.1"
+  - python: pypy3.5-6.0
+    env: TOXENV=pypy3 REQUESTS_VERSION="===2.1.0"
+  - python: nightly
+    env: TOXENV=py
+  - python: nightly
+    env: TOXENV=py REQUESTS_VERSION="===2.2.1"
+  - python: nightly
+    env: TOXENV=py REQUESTS_VERSION="===2.1.0"
   - python: 3.6
     env: TOXENV=noopenssl
-  - env: TOXENV=py27-flake8
-  - env: TOXENV=py34-flake8
+  - python: 2.7
+    env: TOXENV=py27-flake8
+  - python: 3.4
+    env: TOXENV=py34-flake8
   - env: TOXENV=docstrings
   - env: TOXENV=docs
   - env: TOXENV=readme

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy,{py27,py34}-flake8,noopenssl,docstrings
+envlist = py27,py34,py35,py36,py37,pypy,pypy3,{py27,py34}-flake8,noopenssl,docstrings
 
 [testenv]
 pip_pre = False


### PR DESCRIPTION
Use 'dist: xenial' in Travis to allow using Python 3.7.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release