### PR TITLE
Prefer readthedocs.io instead of readthedocs.org for doc links

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,3 @@
 Please read the `documentation
-<https://toolbelt.readthedocs.org/en/latest/contributing.html>`_ to understand
+<https://toolbelt.readthedocs.io/en/latest/contributing.html>`_ to understand
 the suggested workflow to contribute to this project.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -233,7 +233,7 @@ New Features
 
 - A naive implemenation of a thread pool is now included in the toolbelt. See
   the docs in ``docs/threading.rst`` or on `Read The Docs
-  <https://toolbelt.readthedocs.org>`_.
+  <https://toolbelt.readthedocs.io/>`_.
 
 - The ``StreamingIterator`` now accepts files (such as ``sys.stdin``) without
   a specific length and will properly stream them.

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Contributing
 ------------
 
 Please read the `suggested workflow
-<https://toolbelt.readthedocs.org/en/latest/contributing.html>`_ for
+<https://toolbelt.readthedocs.io/en/latest/contributing.html>`_ for
 contributing to this project.
 
 Please report any bugs on the `issue tracker`_

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -7,7 +7,7 @@ requests supports Basic Authentication and HTTP Digest Authentication by
 default. There are also a number of third-party libraries for authentication
 with:
 
-- `OAuth <https://requests-oauthlib.readthedocs.org/en/latest/>`_
+- `OAuth <https://requests-oauthlib.readthedocs.io/>`_
 
 - `NTLM <https://github.com/requests/requests-ntlm>`_
 
@@ -133,7 +133,7 @@ the proxy.
         "http": "http://PROXYSERVER:PROXYPORT",
         "https": "https://PROXYSERVER:PROXYPORT",
     }
-    url = "https://toolbelt.readthedocs.org/"
+    url = "https://toolbelt.readthedocs.io/"
     auth = HTTPProxyDigestAuth("USERNAME", "PASSWORD")
     requests.get(url, proxies=proxies, auth=auth)
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -157,5 +157,5 @@ Footnotes
 
 .. _GitHub: https://github.com/requests/toolbelt
 .. _GitLab: https://gitlab.com/sigmavirus24/toolbelt
-.. _tox: https://tox.readthedocs.org/en/latest/
+.. _tox: https://tox.readthedocs.io/
 .. _pytest: https://docs.pytest.org/

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     license='Apache 2.0',
     author='Ian Cordasco, Cory Benfield',
     author_email="graffatcolmingov@gmail.com",
-    url="https://toolbelt.readthedocs.org",
+    url="https://toolbelt.readthedocs.io/",
     packages=packages,
     package_data={'': ['LICENSE', 'AUTHORS.rst']},
     include_package_data=True,


### PR DESCRIPTION
Read the Docs moved hosting to readthedocs.io instead of
readthedocs.org. Fix all links in the project.

For additional details, see:

https://blog.readthedocs.com/securing-subdomains/

> Starting today, Read the Docs will start hosting projects from
> subdomains on the domain readthedocs.io, instead of on
> readthedocs.org. This change addresses some security concerns around
> site cookies while hosting user generated data on the same domain as
> our dashboard.