### PR TITLE
Drop unnecessary call to .keys()

### DIFF
--- a/requests_toolbelt/utils/dump.py
+++ b/requests_toolbelt/utils/dump.py
@@ -98,7 +98,7 @@ def _dump_response_data(response, prefixes, bytearr):
                    _coerce_to_bytes(response.reason) + b'\r\n')
 
     headers = raw.headers
-    for name in headers.keys():
+    for name in headers:
         for value in headers.getlist(name):
             bytearr.extend(prefix + _format_header(name, value))
 


### PR DESCRIPTION
Iterating a dict is the same as iterating the dict keys.

Inspired by Lennart Regebro PyCon 2017 talk "Prehistoric Patterns in
Python".

https://www.youtube.com/watch?v=V5-JH23Vk0I