### PR TITLE
Replace calls to tuple()/dict() with literals

### DIFF
--- a/requests_toolbelt/multipart/decoder.py
+++ b/requests_toolbelt/multipart/decoder.py
@@ -106,7 +106,7 @@ class MultipartDecoder(object):
         #: Response body encoding
         self.encoding = encoding
         #: Parsed parts of the multipart response body
-        self.parts = tuple()
+        self.parts = ()
         self._find_boundary()
         self._parse_body(content)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -64,7 +64,7 @@ class TestGuessProxyAuth(unittest.TestCase):
     def test_handle_407_header_basic(self, extract_cookies_to_jar, proxy_auth_call):
         req = mock.Mock()
         r = mock.Mock()
-        r.headers = dict()
+        r.headers = {}
         r.request.copy.return_value = req
 
         proxy_auth_call.return_value = requests.Response()


### PR DESCRIPTION
Literals are always slightly faster and more idiomatic.