### PR TITLE
Use skip_install=true for lint or static tox targets

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py27,py34,py35,py36,py37,pypy,pypy3,{py27,py34}-flake8,noopenssl,docstrings
+minversion = 1.9
 
 [testenv]
 pip_pre = False
@@ -29,25 +30,27 @@ basepython = python2.7
 deps =
     flake8
 commands = flake8 {posargs} requests_toolbelt
+skip_install = true
 
 [testenv:py34-flake8]
 basepython = python3.4
 deps =
     flake8
 commands = flake8 {posargs} requests_toolbelt
+skip_install = true
 
 [testenv:docstrings]
 deps =
     flake8
     flake8-docstrings
 commands = flake8 {posargs} requests_toolbelt
+skip_install = true
 
 [testenv:docs]
 deps =
     sphinx>=1.3.0
     sphinx_rtd_theme
     pyopenssl
-    .
 commands =
     sphinx-build -E -c docs -b html docs/ docs/_build/html
 
@@ -56,6 +59,7 @@ deps =
     readme_renderer
 commands =
     python setup.py check -m -r -s
+skip_install = true
 
 [testenv:release]
 deps =
@@ -64,6 +68,7 @@ deps =
 commands =
     python setup.py sdist bdist_wheel
     twine upload --skip-existing dist/*
+skip_install = true
 
 [pytest]
 addopts = -q


### PR DESCRIPTION
Avoids installing the package (and any potential dependencies) to the
virtualenv before running lint or static commands. The package is not
required to be installed to do simple static code analysis. Results in a
slightly faster run, as fetching and installing dependencies is skipped.

For additional information on the configuration option, see:

https://tox.readthedocs.io/en/latest/config.html#confval-skip_install=BOOL

> Do not install the current package. This can be used when you need the
> virtualenv management but do not want to install the current package
> into that environment.

In the absence of skip_install, there is no need to explicitly install
the package. That is done automatically by tox.