### PR TITLE
Drop pytest options from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,3 @@ deps =
 commands =
     python setup.py sdist bdist_wheel
     twine upload --skip-existing dist/*
-
-[pytest]
-addopts = -q
-norecursedirs = *.egg .git .* _*


### PR DESCRIPTION
Use the good defaults of pytest instead. The norecursedirs option didn't
add anything useful not already provided by pytest.

Slightly simplifies the project's configuration and brings it in line
with community defaults.