### PR TITLE
Always close open files in test_multiple_encoder.py

### DIFF
--- a/tests/test_multipart_encoder.py
+++ b/tests/test_multipart_encoder.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import contextlib
 import unittest
 import io
 
@@ -233,24 +234,34 @@ class TestMultipartEncoder(unittest.TestCase):
             "test": "t" * 100
         }
 
-        for x in range(30):
-            fields['f%d' % x] = (
-                'test', open('tests/test_multipart_encoder.py', 'rb')
-                )
+        @contextlib.contextmanager
+        def open_many():
+            files = []
+            try:
+                for x in range(30):
+                    fp = open(__file__, 'rb')
+                    files.append(fp)
+                    fields['f%d' % x] = ('test', fp)
+                yield
+            finally:
+                while files:
+                    fp = files.pop()
+                    fp.close()
 
-        m = MultipartEncoder(fields=fields)
-        total_size = m.len
+        with open_many():
+            m = MultipartEncoder(fields=fields)
+            total_size = m.len
 
-        blocksize = 8192
-        read_so_far = 0
+            blocksize = 8192
+            read_so_far = 0
 
-        while True:
-            data = m.read(blocksize)
-            if not data:
-                break
-            read_so_far += len(data)
+            while True:
+                data = m.read(blocksize)
+                if not data:
+                    break
+                read_so_far += len(data)
 
-        assert read_so_far == total_size
+            assert read_so_far == total_size
 
     def test_regression_2(self):
         """Ensure issue #31 doesn't ever happen again."""


### PR DESCRIPTION
When running tests with Python warnings enabled, fixes the warning:

    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
    tests/test_multipart_encoder.py::TestMultipartEncoder::test_regresion_1
      /usr/lib64/python3.7/unittest/case.py:632: ResourceWarning: unclosed file <_io.BufferedReader name='tests/test_multipart_encoder.py'>
        testMethod()