### PR TITLE
Enable SNI in request TLS Client Hello package

### DIFF
--- a/requests_toolbelt/adapters/host_header_ssl.py
+++ b/requests_toolbelt/adapters/host_header_ssl.py
@@ -35,6 +35,7 @@ class HostHeaderSSLAdapter(HTTPAdapter):
         connection_pool_kwargs = self.poolmanager.connection_pool_kw
 
         if host_header:
+            connection_pool_kwargs['server_hostname'] = host_header
             connection_pool_kwargs["assert_hostname"] = host_header
         elif "assert_hostname" in connection_pool_kwargs:
             # an assert_hostname from a previous request may have been left


### PR DESCRIPTION
without connection_pool_kwargs['server_hostname'] = host_header, reqeust TLS HELLO package will be sent without SNI extension; 
And this will cause SSLCertVerificationError for sites with multi domain name and certifications