### PR TITLE
handle Host header that includes port

### DIFF
--- a/requests_toolbelt/adapters/host_header_ssl.py
+++ b/requests_toolbelt/adapters/host_header_ssl.py
@@ -35,6 +35,9 @@ class HostHeaderSSLAdapter(HTTPAdapter):
         connection_pool_kwargs = self.poolmanager.connection_pool_kw
 
         if host_header:
+            # host header can include port, but we should not include it in the assert hostname
+            host_header = host_header.split(':')[0]
+
             connection_pool_kwargs["assert_hostname"] = host_header
         elif "assert_hostname" in connection_pool_kwargs:
             # an assert_hostname from a previous request may have been left

--- a/tests/test_host_header_ssl_adapter.py
+++ b/tests/test_host_header_ssl_adapter.py
@@ -7,10 +7,12 @@ from requests_toolbelt.adapters import host_header_ssl as hhssl
 @pytest.fixture
 def session():
     """Create a session with our adapter mounted."""
-    session = requests.Session()
-    session.mount('https://', hhssl.HostHeaderSSLAdapter())
+    s = requests.Session()
+    s.mount('https://', hhssl.HostHeaderSSLAdapter())
+    return s
 
 
+# Let's not spam example.org:
 @pytest.mark.skip
 class TestHostHeaderSSLAdapter(object):
     """Tests for our HostHeaderSNIAdapter."""
@@ -30,14 +32,19 @@ class TestHostHeaderSSLAdapter(object):
                         headers={'Host': 'example.com'})
         assert r.status_code == 200
 
-    def test_stream(self):
-        self.session.get('https://54.175.219.8/stream/20',
-                         headers={'Host': 'httpbin.org'},
-                         stream=True)
+    def test_stream(self, session):
+        session.get('https://54.175.219.8/stream/20',
+                    headers={'Host': 'httpbin.org'},
+                    stream=True)
 
-    def test_case_insensitive_header(self):
-        r = self.session.get('https://93.184.216.34',
-                             headers={'hOSt': 'example.org'})
+    def test_case_insensitive_header(self, session):
+        r = session.get('https://93.184.216.34',
+                        headers={'hOSt': 'example.org'})
+        assert r.status_code == 200
+
+    def test_case_header_with_port(self, session):
+        r = session.get('https://93.184.216.34',
+                        headers={'Host': 'example.org:443'})
         assert r.status_code == 200
 
     def test_plain_requests(self):


### PR DESCRIPTION
Host headers can include the port.  We should not include them when setting assert_hostname. 

Closes #288