### PR TITLE
Switch to unittest.mock instead of mock

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -53,3 +53,5 @@ Patches and Suggestions
 - Ryan Ashley <rashley-iqt>
 
 - Sam Bull (@greatestape)
+
+- Florence Blanc-Renaud <flo@redhat.com> (@flo-renaud)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 pytest
-mock
+mock;python_version<"3.3"
 pyopenssl
 git+git://github.com/sigmavirus24/betamax

--- a/tests/test_appengine_adapter.py
+++ b/tests/test_appengine_adapter.py
@@ -2,7 +2,10 @@
 """Tests for the AppEngineAdapter."""
 import sys
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 import requests
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import requests
 import unittest
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from requests_toolbelt.auth.guess import GuessAuth, GuessProxyAuth
 from . import get_betamax

--- a/tests/test_downloadutils.py
+++ b/tests/test_downloadutils.py
@@ -8,7 +8,10 @@ import tempfile
 import requests
 from requests_toolbelt.downloadutils import stream
 from requests_toolbelt.downloadutils import tee
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from . import get_betamax

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -12,7 +12,10 @@ very complex and high-level.
 from requests_toolbelt._compat import HTTPHeaderDict
 from requests_toolbelt.utils import dump
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 import requests
 

--- a/tests/test_multipart_decoder.py
+++ b/tests/test_multipart_decoder.py
@@ -2,7 +2,10 @@
 import io
 import sys
 import unittest
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 import requests
 from requests_toolbelt.multipart.decoder import BodyPart

--- a/tests/test_proxy_digest_auth.py
+++ b/tests/test_proxy_digest_auth.py
@@ -2,7 +2,10 @@
 """Test proxy digest authentication."""
 
 import unittest
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import requests
 from requests_toolbelt.auth import http_proxy_digest

--- a/tests/test_socket_options_adapter.py
+++ b/tests/test_socket_options_adapter.py
@@ -3,7 +3,10 @@
 import contextlib
 import socket
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import requests
 from requests_toolbelt._compat import poolmanager
 

--- a/tests/test_source_adapter.py
+++ b/tests/test_source_adapter.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from requests.adapters import DEFAULT_POOLSIZE, DEFAULT_POOLBLOCK
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 from requests_toolbelt.adapters.source import SourceAddressAdapter
 
 import pytest

--- a/tests/test_ssladapter.py
+++ b/tests/test_ssladapter.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 import requests
 import unittest

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -2,7 +2,10 @@
 import unittest
 import sys
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 import pytest
 
 from requests_toolbelt.utils import user_agent as ua

--- a/tests/threaded/test_api.py
+++ b/tests/threaded/test_api.py
@@ -1,6 +1,9 @@
 """Module containing tests for requests_toolbelt.threaded API."""
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from requests_toolbelt._compat import queue

--- a/tests/threaded/test_pool.py
+++ b/tests/threaded/test_pool.py
@@ -5,7 +5,10 @@ except ImportError:
     import Queue as queue
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from requests_toolbelt.threaded import pool

--- a/tests/threaded/test_thread.py
+++ b/tests/threaded/test_thread.py
@@ -7,7 +7,10 @@ import threading
 import unittest
 import uuid
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import requests.exceptions
 
 from requests_toolbelt.threaded import thread

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ pip_pre = False
 deps =
     requests{env:REQUESTS_VERSION:>=2.0.1,<3.0.0}
     pytest
-    mock
+    mock;python_version<"3.3"
     pyopenssl
     ndg-httpsclient
     betamax>0.5.0
@@ -19,7 +19,7 @@ pip_pre = False
 deps =
     requests{env:REQUESTS_VERSION:>=2.0.1,<3.0.0}
     pytest
-    mock
+    mock;python_version<"3.3"
     betamax>0.5.0
 commands =
     py.test {posargs}


### PR DESCRIPTION
mock is now part of the python standard library, and
python-mock will be deprecated in Fedora34
(see https://fedoraproject.org/wiki/Changes/DeprecatePythonMock)

Follow the recommendation to use
    from unittest import mock
instead of
    import mock
and conditionalize the dependency.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>