### PR TITLE
Fix docstring typo

### DIFF
--- a/requests_toolbelt/adapters/socket_options.py
+++ b/requests_toolbelt/adapters/socket_options.py
@@ -84,9 +84,9 @@ class TCPKeepAliveAdapter(SocketOptionsAdapter):
 
     The latter three can be overridden by keyword arguments (respectively):
 
-    - ``idle``
     - ``interval``
     - ``count``
+    - ``idle``
 
     You can use this adapter like so::
 


### PR DESCRIPTION
Keyword arguments to `TCPKeepAliveAdapter` are in the wrong order in the docstring (i.e. not "respectively" as intended)

Many thanks