### PR TITLE
Address cases where MultipartEncoder source stream grows or shrinks mid-way through encoding, leading to malformed requests

### DIFF
--- a/requests_toolbelt/exceptions.py
+++ b/requests_toolbelt/exceptions.py
@@ -35,3 +35,17 @@ class IgnoringGAECertificateValidation(Warning):
     In :class:`requests_toolbelt.adapters.appengine.InsecureAppEngineAdapter`.
     """
     pass
+
+
+class MultipartEncoderSourceShrunkError(Exception):
+    """Used to indicate that a data source passed to
+    :class:`requests_toolbelt.multipart.encoder.MultipartEncoder` shrunk in
+    size during encoding.
+
+    If the data source shrinks during encoding, the overall encoded data
+    length would no longer match the initially calculated length (sent to the
+    server as ``Content-Length``), potentially causing an HTTP 408 request
+    timeout error.
+
+    """
+    pass


### PR DESCRIPTION
Previously, MultipartEncoder in conjunction with requests could produce a malformed request if the source data stream grew (e.g. appending to a log file being uploaded) or shrunk during encoding. This change addresses both the growing case (by only transmitting the originally promised amount of data) and the shrinking case (by raising an exception).

Note that the data produced by MultipartEncoder itself was well formed. The issue occurs when downstream code makes promises or assumptions based on the initial `len` (e.g. transmitting it to the server as `Content-Length`, as requests does), only to have the encoder return more/less data. This change may break (presumably rare) use cases that rely on both a) on shrinking/growing the source data stream during encoding, and b) don't already fail due to the promised/actual encoded data length mismatch.