### PR TITLE
Add filename hinting to multipart encoder

### DIFF
--- a/requests_toolbelt/multipart/encoder.py
+++ b/requests_toolbelt/multipart/encoder.py
@@ -228,6 +228,7 @@ class MultipartEncoder(object):
                 else:
                     file_name, file_pointer, file_type, file_headers = v
             else:
+                file_name = requests.utils.guess_filename(v)
                 file_pointer = v
 
             field = fields.RequestField(name=k, data=file_pointer,


### PR DESCRIPTION
Allow the multipart encoder to do the same filename hinting as `requests` does.