### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     author_email="graffatcolmingov@gmail.com",
     url="https://toolbelt.readthedocs.io/",
     project_urls={
+        "Changelog": "https://github.com/requests/toolbelt/blob/master/HISTORY.rst",
         "Source": "https://github.com/requests/toolbelt",
     },
     packages=packages,

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ setup(
     author='Ian Cordasco, Cory Benfield',
     author_email="graffatcolmingov@gmail.com",
     url="https://toolbelt.readthedocs.io/",
+    project_urls={
+        "Source": "https://github.com/requests/toolbelt",
+    },
     packages=packages,
     package_data={'': ['LICENSE', 'AUTHORS.rst']},
     include_package_data=True,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.