### PR TITLE
Release 0.10.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,19 @@
 History
 =======
 
+0.10.0 -- 2022-10-06
+-------------------
+
+New Features
+~~~~~~~~~~~~
+
+- Add support for preparing requests in BaseUrlSession
+
+Fixed Bugs
+~~~~~~~~~~
+
+- Fixing missing newline in dump utility
+
 0.9.1 -- 2019-01-29
 -------------------
 

--- a/requests_toolbelt/__init__.py
+++ b/requests_toolbelt/__init__.py
@@ -22,7 +22,7 @@ __title__ = 'requests-toolbelt'
 __authors__ = 'Ian Cordasco, Cory Benfield'
 __license__ = 'Apache v2.0'
 __copyright__ = 'Copyright 2014 Ian Cordasco, Cory Benfield'
-__version__ = '0.9.1'
+__version__ = '0.10.0'
 __version_info__ = tuple(int(i) for i in __version__.split('.'))
 
 __all__ = [


### PR DESCRIPTION
After discussions in https://github.com/psf/requests/issues/6219, I'd like to release a new version that fixes the urllib3 warnings reported in #331. But before that, it seemed fitting to release the various changes made in the past three years, even if most of them did not make it to the release notes.

@achapkowski I can't assign you, but I would appreciate if you could double check that I have not missed anything.

@sigmavirus24 I can handle the "upload to PyPI part" too if you want. I'm https://pypi.org/user/quentinp/ on PyPI.