### PR TITLE
Remove `BaseURLSession.request` method

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -55,3 +55,5 @@ Patches and Suggestions
 - Sam Bull (@greatestape)
 
 - Florence Blanc-Renaud <flo@redhat.com> (@flo-renaud)
+
+- Theron Luhn (https://github.com/luhn)

--- a/requests_toolbelt/sessions.py
+++ b/requests_toolbelt/sessions.py
@@ -70,13 +70,6 @@ class BaseUrlSession(requests.Session):
             self.base_url = base_url
         super(BaseUrlSession, self).__init__()
 
-    def request(self, method, url, *args, **kwargs):
-        """Send the request after generating the complete URL."""
-        url = self.create_url(url)
-        return super(BaseUrlSession, self).request(
-            method, url, *args, **kwargs
-        )
-
     def prepare_request(self, request, *args, **kwargs):
         """Prepare the request after generating the complete URL."""
         request.url = self.create_url(request.url)


### PR DESCRIPTION
`Session.request` calls `prepare_request`, so `BaseURLSession.request` is redundant with `BaseURLSession.prepare_request`.