### PR TITLE
Release 1.0.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,16 +1,23 @@
 History
 =======
 
-1.0.0 -- 2023-XX-XX
+1.0.0 -- 2023-05-01
 -------------------
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
-- Removed Google App Engine support
+- Removed Google App Engine support to allow using urllib3 2.0
 
 Fixed Bugs
 ~~~~~~~~~~
+
+- Ensured the test suite no longer reaches the Internet
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+- Added explicit support for Python 3.11
 
 0.10.1 -- 2022-10-25
 --------------------

--- a/requests_toolbelt/__init__.py
+++ b/requests_toolbelt/__init__.py
@@ -22,7 +22,7 @@ __title__ = 'requests-toolbelt'
 __authors__ = 'Ian Cordasco, Cory Benfield'
 __license__ = 'Apache v2.0'
 __copyright__ = 'Copyright 2014 Ian Cordasco, Cory Benfield'
-__version__ = '0.10.1'
+__version__ = '1.0.0'
 __version_info__ = tuple(int(i) for i in __version__.split('.'))
 
 __all__ = [


### PR DESCRIPTION
While the tests don't support urllib3 2.0 yet, https://github.com/requests/toolbelt/pull/356 shows that the code itself does. But since #356 needs more work to be merged (including work in Betamax), I'd like to release a new version soon as users are already affected, as reported in https://github.com/urllib3/urllib3/issues/2997.

Regarding the version number, @sigmavirus24 suggested 1.0 here: https://github.com/requests/toolbelt/pull/355#issuecomment-1527673933.

The release date is tentative. If this pull request is approved but the date changes, I plan to change it without asking for a review depending on when I have the time to release.