### PR TITLE
Support HTTPResponse object as file in MultipartEncoder

### DIFF
--- a/requests_toolbelt/multipart/encoder.py
+++ b/requests_toolbelt/multipart/encoder.py
@@ -431,6 +431,9 @@ def total_len(o):
 
     if hasattr(o, 'len'):
         return o.len
+    
+    if hasattr(o, 'getheader'):
+        return int(o.getheader('Content-Length', 0))
 
     if hasattr(o, 'fileno'):
         try:


### PR DESCRIPTION
Added content length for HTTPResponse in MultipartEncoder to support posting multipart data from streaming response.

Use case:
```py
import requests
from requests_toolbelt.multipart.encoder import MultipartEncoder

# Define the URLs
download_url = "download_url"
upload_url = 'upload_url'

# Download the content as a stream
with requests.get(download_url, stream=True) as download_response:
    # Check if the download was successful
    if download_response.status_code == 200:

        encoder = MultipartEncoder(
            fields={'file': ('10mb.bin', download_response.raw, 'application/octet-stream')}
        )

        # Stream the downloaded content directly to the upload URL
        with requests.post(upload_url, data=encoder, headers={"Content-Type": encoder.content_type}) as upload_response:
            if upload_response.status_code == 200:
                print("Upload successful!")
            else:
                print(f"Upload failed with status code: {upload_response.status_code}")
    else:
        print(f"Failed to download content. Status code: {download_response.status_code}")
```

Tested with multiple URLs
Example URLs:
Download URL: https://mirror.nforce.com/pub/speedtests/10mb.bin
Upload URL: https://file.io