### PR TITLE
Handle pickle in `BaseUrlSession` for `base_url`

### DIFF
--- a/requests_toolbelt/sessions.py
+++ b/requests_toolbelt/sessions.py
@@ -87,3 +87,15 @@ class BaseUrlSession(requests.Session):
     def create_url(self, url):
         """Create the URL based off this partial path."""
         return urljoin(self.base_url, url)
+
+    def __getstate__(self):
+        """Save base URL as well during the pickle"""
+        states = super(BaseUrlSession, self).__getstate__()
+        states.update({"base_url": self.base_url})
+        return states
+
+    def __setstate__(self, state):
+        """Load base URL as well during the unpickle"""
+        super(BaseUrlSession, self).__setstate__(state)
+        if "base_url" in state:
+            self.base_url = state["base_url"]

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
+import pickle
 import pytest
 
 from requests_toolbelt import sessions
@@ -53,3 +54,9 @@ class TestBasedSession(unittest.TestCase):
             response = session.send(prepared_request)
         response.raise_for_status()
         assert response.json()['headers']['Host'] == 'httpbin.org'
+
+    def test_pickle_unpickle_session(self):
+        session = sessions.BaseUrlSession('https://www.google.com')
+        pickled_session = pickle.dumps(session)
+        unpickled_session = pickle.loads(pickled_session)
+        assert session.base_url == unpickled_session.base_url


### PR DESCRIPTION
- Add `base_url` when `__getstate__` is called
- Try to take `base_url` when `__setstate__` is called