### PR TITLE
support nested multipart and no-conent parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ build/
 *.egg
 .env
 .cache/
+.vscode
+.idea

--- a/requests_toolbelt/multipart/decoder.py
+++ b/requests_toolbelt/multipart/decoder.py
@@ -59,7 +59,18 @@ class BodyPart(object):
             first, self.content = _split_on_find(content, b'\r\n\r\n')
             if first != b'':
                 headers = _header_parser(first.lstrip(), encoding)
+        # because pre-split by boundary was done,
+        # having only a single newline and the '--'
+        # means that this is a 'no content' part
+        elif content.endswith(b'\r\n') and not content.endswith(b'\r\n\r\n'):
+            self.content = None
+            headers = _header_parser(content.strip(), encoding)
+            if not headers:
+                raise ImproperBodyPartContentException(
+                    'No contents part without any header is invalid.'
+                )
         else:
+            print("==" + content.decode() + "===")
             raise ImproperBodyPartContentException(
                 'content does not contain CR-LF-CR-LF'
             )
@@ -68,6 +79,8 @@ class BodyPart(object):
     @property
     def text(self):
         """Content of the ``BodyPart`` in unicode."""
+        if self.content is None:
+            return None
         return self.content.decode(self.encoding)
 
 

--- a/requests_toolbelt/multipart/encoder.py
+++ b/requests_toolbelt/multipart/encoder.py
@@ -21,7 +21,12 @@ class FileNotSupportedError(Exception):
     """File not supported error."""
 
 
-class MultipartEncoder(object):
+class ContentIO(object):
+    def __init__(self, no_content=False):
+        self.no_content = no_content
+
+
+class MultipartEncoder(ContentIO):
 
     """
 
@@ -85,6 +90,8 @@ class MultipartEncoder(object):
     """
 
     def __init__(self, fields, boundary=None, encoding='utf-8', content_type='multipart/form-data'):
+        ContentIO.__init__(self)
+
         #: Boundary value either passed in by the user or created
         self.boundary_value = boundary or uuid4().hex
 
@@ -325,7 +332,7 @@ def IDENTITY(monitor):
     return monitor
 
 
-class MultipartEncoderMonitor(object):
+class MultipartEncoderMonitor(ContentIO):
 
     """
     An object used to monitor the progress of a :class:`MultipartEncoder`.
@@ -377,6 +384,8 @@ class MultipartEncoderMonitor(object):
     """
 
     def __init__(self, encoder, callback=None):
+        ContentIO.__init__(self)
+
         #: Instance of the :class:`MultipartEncoder` being monitored
         self.encoder = encoder
 
@@ -509,6 +518,9 @@ class Part(object):
         :returns: bool -- ``True`` if there are bytes left to write, otherwise
             ``False``
         """
+        if getattr(self.body, "finished", False):  # part is a nested multipart and has finished reading
+            return False
+
         to_read = 0
         if self.headers_unread:
             to_read += len(self.headers)
@@ -535,13 +547,10 @@ class Part(object):
             if size != -1:
                 amount_to_read = size - written
             written += buffer.append(self.body.read(amount_to_read))
+            if getattr(self, 'bytes_left_to_write', False):
+                return written
 
         return written
-
-
-class ContentIO(object):
-    def __init__(self, no_content=False):
-        self.no_content = no_content
 
 
 class CustomBytesIO(ContentIO, io.BytesIO):


### PR DESCRIPTION
- Given a part that has "no content" (`None`) (as if it was returned on its own by an HTTP 204 No Content response), `MultipartEncoder` will not incorrectly insert a second `\r\n` anymore. A parser that strictly interprets the amount of `\r\n` can distinguish a "no content" part from an "empty string" part, which can have different meanings depending on the embedded `Content-Type` (e.g.: a `null` vs `""` for JSON).

- Fixes #352.
  Multipart decoder correctly understands a single `\r\n` used to separate the headers from the "no content" body. The resulting part returns `None` rather than `""`.

- Add a `content_type` parameter to `__init__` allowing to override the default `multipart/form-data` that was hard-coded.

- Support nested multipart.
  Using the `MultipartEncoder` as `file_pointer` in the input `fields` of another `MultipartEncoder` will correctly nest the contents, with their respective boundaries. This can be used to form complex structures of `multipart/mixed`,  `multipart/alternate`,  `multipart/related` commonly used when combining various attachment representations.