### PR TITLE
Fix len detection on ZipExtFile file

### DIFF
--- a/requests_toolbelt/multipart/encoder.py
+++ b/requests_toolbelt/multipart/encoder.py
@@ -432,6 +432,10 @@ def total_len(o):
     if hasattr(o, 'len'):
         return o.len
 
+    # Support ZipExtFile file
+    if hasattr(o, "_orig_file_size"):
+        return o._orig_file_size
+
     if hasattr(o, 'fileno'):
         try:
             fileno = o.fileno()


### PR DESCRIPTION
Currently, streaming file with the MultipartEncoder doesn't work en ZipExtFile  file.

ZipExtFile  is a file-like object providen by ZipFile.
This is due to the fact that ZipExtFile doesn't have a `len` attribute.

We extract file size from the internal `_orig_file_size` attribute.